### PR TITLE
Fix .gitignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ __pycache__/
 *.pyo
 *.pyd
 .Python
-*.logsecrets.txt 
+*.log
+secrets.txt 


### PR DESCRIPTION
## Summary
- split the `*.logsecrets.txt` line in `.gitignore` into separate entries for `*.log` and `secrets.txt`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68417c6f2114832aa9766c164d1b1d2b